### PR TITLE
Looks like Lion added a semicolon to PROMPT_COMMAND in /etc/bashrc.

### DIFF
--- a/autojump.conf
+++ b/autojump.conf
@@ -28,6 +28,7 @@ _autojump()
 complete -F _autojump j
 AUTOJUMP='{ (autojump -a "$(pwd -P)"&)>/dev/null 2>>${HOME}/.autojump_errors;} 2>/dev/null'
 if [[ ! $PROMPT_COMMAND =~ autojump ]]; then
+  PROMPT_COMMAND=`echo $PROMPT_COMMAND | sed 's/;\s*$//g'` # remove trailing ';'
   export PROMPT_COMMAND="${PROMPT_COMMAND:-:} && $AUTOJUMP"
 fi
 alias jumpstat="autojump --stat"


### PR DESCRIPTION
This made my errors go away.
